### PR TITLE
support both shift and ctrl keys instread of ctrl only for multi-select

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -841,7 +841,7 @@ export class Topology {
       // Click a line.
       case MoveInType.Line:
       case MoveInType.LineControlPoint:
-        if (e.ctrlKey) {
+        if (e.ctrlKey || e.shiftKey) {
           this.activeLayer.add(this.moveIn.hoverLine);
           this.dispatch("multi", this.activeLayer.pens);
         } else {
@@ -897,7 +897,7 @@ export class Topology {
           break;
         }
 
-        if (e.ctrlKey) {
+        if (e.ctrlKey || e.shiftKey) {
           if (
             this.moveIn.hoverNode &&
             this.activeLayer.hasInAll(this.moveIn.hoverNode)
@@ -912,7 +912,7 @@ export class Topology {
               this.dispatch("node", this.moveIn.activeNode);
             }
           }
-        } else if (e.shiftKey || e.altKey) {
+        } else if (e.altKey) {
           if (this.moveIn.hoverNode) {
             this.activeLayer.setPens([this.moveIn.hoverNode]);
             this.dispatch("node", this.moveIn.hoverNode);


### PR DESCRIPTION
PowerPoint and WPS use shift too. In addition, on macOS, Ctrl + mouse left button is an alias of mouse right button, which triggers context menu.