### PR TITLE
feat(core): 增加图形居中和自适应

### DIFF
--- a/examples/angular/src/app/workspace/header/header.component.html
+++ b/examples/angular/src/app/workspace/header/header.component.html
@@ -153,8 +153,20 @@
     <div class="separator"></div>
     <div class="item mh5">
       视图：{{ data.scale * 100 | number: ".0-2" }}%
-      <a class="hover" *ngIf="data.scale !== 1" (click)="onMenu('scale', 1)" style="padding-right: 0;">
+      <a  title="还原原始尺寸" class="hover" *ngIf="data.scale !== 1" (click)="onMenu('scale', 1)" style="padding-right: 0;">
         还原
+      </a>
+    </div>
+    <div class="separator"></div>
+    <div class="item mh5">
+      <a  (click)="onMenu('fitView')" title='图形居中，并且缩放图形到画布尺寸' >
+        自适应
+      </a>
+    </div>
+    <div class="separator"></div>
+    <div class="item mh5">
+      <a  (click)="onMenu('centerView')" title='居中图形' >
+        居中
       </a>
     </div>
     <div class="separator"></div>

--- a/examples/angular/src/app/workspace/workspace.component.ts
+++ b/examples/angular/src/app/workspace/workspace.component.ts
@@ -180,6 +180,12 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
           this.router.navigateByUrl(`/view?id=${this.data.id}${this.data.version ? '&version=' + this.data.version : ''}&r=1`);
         }
         break;
+      case "fitView":
+        this.canvas.fitView();
+        break;
+      case "centerView":
+        this.canvas.centerView();
+        break;
     }
   }
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -12,6 +12,8 @@ export enum KeydownType {
   Canvas,
 }
 
+export type Padding = number | string | number[];
+
 export interface Options {
   cacheLen?: number;
   extDpiRatio?: number;
@@ -58,6 +60,8 @@ export interface Options {
   maxScale?: number;
   autoExpandDistance?: number;
   keydown?: KeydownType;
+  fitView?: boolean;
+  fitViewPadding?: Padding;
   on?: (event: string, data: any) => void;
 }
 
@@ -86,4 +90,6 @@ export const DefalutOptions: Options = {
   maxScale: 5,
   autoExpandDistance: 200,
   keydown: KeydownType.Document,
+  fitView: false,
+  fitViewPadding: 0,
 };

--- a/packages/core/src/utils/padding.ts
+++ b/packages/core/src/utils/padding.ts
@@ -1,0 +1,48 @@
+import { Padding } from '../options';
+
+/**
+ * turn padding into [top, right, bottom, right]
+ * @param  {Number|Array} padding input padding
+ * @return {array} output
+ */
+export const formatPadding = (padding: Padding): number[] => {
+  let top = 0;
+  let left = 0;
+  let right = 0;
+  let bottom = 0;
+
+  if (typeof padding === 'number') {
+    top = left = right = bottom = padding;
+  } else if (typeof padding === 'string') {
+    const intPadding = parseInt(padding, 10);
+    top = left = right = bottom = intPadding;
+  } else if (Array.isArray(padding)) {
+    top = padding[0];
+    right = !isNil(padding[1]) ? padding[1] : padding[0];
+    bottom = !isNil(padding[2]) ? padding[2] : padding[0];
+    left = !isNil(padding[3]) ? padding[3] : right;
+  }
+  return [top, right, bottom, left];
+};
+
+/**
+ * Checks if `value` is `null` or `undefined`.
+ *
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is nullish, else `false`.
+ * @example
+ *
+ * isNil(null)
+ * // => true
+ *
+ * isNil(void 0)
+ * // => true
+ *
+ * isNil(NaN)
+ * // => false
+ */
+function isNil(value: any): boolean {
+  return value == null;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/le5le-com/topology/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

1. 图形居中
2. 图形自适应画布

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 初始化时自动适应画布
配置项中增加配置：
```js
{
  fitView: true,
  fitViewPaddifng:1
}
```
`fitViewPadding`为自适应画布时的四周留白，格式为：`Padding = number | string | number[];`

## 手动
```js
canvas.fitView()
```
调用此方法时，画布尺寸会被重置为容器尺寸并且缩放图形

## 图形居中
```js
canvas.centerView()
```
# 新增配置和方法
## 配置项
- fixView  
初始化时是否自动自适应
- fitViewPaddifng  
自适应时的留白
## 实例方法
- centerView()  
图形居中
- fitView()  
自适应画布
- rivate hasView()  
判断画布中是否有图形
- private getFormatPadding()  
获取留白值
- private getViewCenter()  
获取画布的中心坐标
