### PR TITLE
fix(core.ts): 修复旧版本浏览器节点拖出后无法选中bug

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -622,7 +622,7 @@ export class Topology {
       }
       if (b) {
         const canvasPos = this.divLayer.canvas.getBoundingClientRect() as DOMRect;
-        this.translate(e.x - this.mouseDown.x - canvasPos.x, e.y - this.mouseDown.y - canvasPos.y, true);
+        this.translate(e.x - this.mouseDown.x - (canvasPos.x || canvasPos.left), e.y - this.mouseDown.y - (canvasPos.y || canvasPos.top), true);
         return false;
       }
     }
@@ -633,7 +633,7 @@ export class Topology {
 
     this.scheduledAnimationFrame = true;
     const canvasPos = this.divLayer.canvas.getBoundingClientRect() as DOMRect;
-    const pos = new Point(e.x - canvasPos.x, e.y - canvasPos.y);
+    const pos = new Point(e.x - (canvasPos.x || canvasPos.left), e.y - (canvasPos.y || canvasPos.top));
 
     if (this.raf) cancelAnimationFrame(this.raf);
     this.raf = requestAnimationFrame(() => {
@@ -810,7 +810,7 @@ export class Topology {
     if (e.button !== 0) return;
 
     const canvasPos = this.divLayer.canvas.getBoundingClientRect() as DOMRect;
-    this.mouseDown = { x: e.x - canvasPos.x, y: e.y - canvasPos.y };
+    this.mouseDown = { x: e.x - (canvasPos.x || canvasPos.left), y: e.y - (canvasPos.y || canvasPos.top) };
     if (e.altKey) {
       this.divLayer.canvas.style.cursor = 'move';
     }
@@ -1041,7 +1041,7 @@ export class Topology {
     if (this.moveIn.hoverNode) {
       this.dispatch('dblclick', this.moveIn.hoverNode);
 
-      if (this.moveIn.hoverNode.getTextRect().hit(new Point(e.x - canvasPos.x, e.y - canvasPos.y))) {
+      if (this.moveIn.hoverNode.getTextRect().hit(new Point(e.x - (canvasPos.x || canvasPos.left), e.y - (canvasPos.y || canvasPos.top)))) {
         this.showInput(this.moveIn.hoverNode);
       }
 
@@ -1051,7 +1051,7 @@ export class Topology {
 
       if (
         !this.moveIn.hoverLine.text ||
-        this.moveIn.hoverLine.getTextRect().hit(new Point(e.x - canvasPos.x, e.y - canvasPos.y))
+        this.moveIn.hoverLine.getTextRect().hit(new Point(e.x - (canvasPos.x || canvasPos.left), e.y - (canvasPos.y || canvasPos.top)))
       ) {
         this.showInput(this.moveIn.hoverLine);
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/le5le-com/topology/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
fix：修复在旧版本浏览器上拖出节点无法选中的bug，可以在chrome 44上重现，步骤如下：
1. 从左侧图框中拖出任意节点，可以正常拖出且可正常编辑；
2. 节点失焦后无法点击选中。

Issue Number: N/A


## What is the new behavior?
1. 从左侧图框中拖出任意节点，可以正常拖出且可正常编辑；
2. 节点失焦后可重新选中正常编辑。

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
