### PR TITLE
fix: 修复 Rect 中包含线时, 区域计算不正确的问题

### DIFF
--- a/packages/core/src/utils/rect.ts
+++ b/packages/core/src/utils/rect.ts
@@ -22,6 +22,9 @@ export function getRect(pens: Pen[]) {
         item.children.forEach((child: Line) => {
           points.push(child.from);
           points.push(child.to);
+          if (Array.isArray(child.controlPoints)) {
+            points.push(...child.controlPoints)
+          }
           if (child.name === 'curve') {
             for (let i = 0.01; i < 1; i += 0.02) {
               points.push(getBezierPoint(i, child.from, child.controlPoints[0], child.controlPoints[1], child.to));
@@ -31,6 +34,9 @@ export function getRect(pens: Pen[]) {
       } else if (item.from) {
         points.push(item.from);
         points.push(item.to);
+        if (Array.isArray(item.controlPoints)) {
+          points.push(...item.controlPoints)
+        }
         if (item.name === 'curve') {
           for (let i = 0.01; i < 1; i += 0.02) {
             points.push(getBezierPoint(i, item.from, item.controlPoints[0], item.controlPoints[1], item.to));


### PR DESCRIPTION
计算 Rect 区域时，除了曲线其它的线是根据起点和终点来计算的，未考虑其中的控制转折点，这样会导致会把部分线漏掉。

* 画布上的原始图：
![image](https://user-images.githubusercontent.com/11495164/114806139-d1010800-9dd6-11eb-87b1-883e5c9d5281.png)

* 导出为 PNG 之后缺失了一部分线段：
![image](https://user-images.githubusercontent.com/11495164/114806182-e1b17e00-9dd6-11eb-95af-306ee6a98623.png)

* 将控制点包含进去修复后：
![image](https://user-images.githubusercontent.com/11495164/114806228-f9890200-9dd6-11eb-96e2-a85c5c6f1eef.png)
