### PR TITLE
refactor: 优化线被选中时的样式便于识别

### DIFF
--- a/packages/core/src/activeLayer.ts
+++ b/packages/core/src/activeLayer.ts
@@ -617,6 +617,8 @@ export class ActiveLayer extends Layer {
           (tmp.fromArrowSize * scale - 1.5 * tmp.lineWidth) / scale;
         tmp.setTID(TID);
         tmp.strokeStyle = rgba(0.2, this.options.activeColor);
+        tmp.borderWidth = 4;
+        tmp.borderColor = rgba(0.1, this.options.activeColor);
         tmp.fromArrowColor = this.options.activeColor;
         tmp.toArrowColor = this.options.activeColor;
         tmp.render(ctx);


### PR DESCRIPTION
选中的线段和未选中的线段样式看起来区别不太大，加了点 border 使其区别更明显便于区分：
* 之前：
<img width="596" alt="old" src="https://user-images.githubusercontent.com/11495164/115374813-c47a1680-a1ff-11eb-800d-e8b2c215b6c4.png">

* 更新后：
<img width="548" alt="new" src="https://user-images.githubusercontent.com/11495164/115374797-c17f2600-a1ff-11eb-8318-ebb444303e6d.png">
