### PR TITLE
fix(core): 修复 TopologyData 缺失的用户自定义数据字段类型

### DIFF
--- a/packages/core/src/models/data.ts
+++ b/packages/core/src/models/data.ts
@@ -37,6 +37,7 @@ export interface TopologyData {
   socketEvent?: boolean | number;
   socketFn?: string;
   initJS?: string;   // 初始化时所执行 js
+  data?: any;
 }
 
 export function createData(json?: any, tid?: string) {


### PR DESCRIPTION
在文档中 TopologyData 有一个用户自定义的数据字段类型，但实际使用的时候会提示不存在这个字段：
![image](https://user-images.githubusercontent.com/11495164/130401961-b11fa33f-f3e1-4b5a-b835-42bdce14b8ce.png)
