### PR TITLE
fix(core): 修复 Topology.open 方法参数类型错误

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -726,8 +726,8 @@ export class Topology {
   };
 
   // open - redraw by the data
-  open(data?: TopologyData) {
-    if (data && data.mqttOptions && !data.mqttOptions.customClientId) {
+  open(data?: TopologyData | string) {
+    if (typeof data !== 'string' && data && data.mqttOptions && !data.mqttOptions.customClientId) {
       data.mqttOptions.clientId = s8();
     }
     this.canvas.clearBkImg();


### PR DESCRIPTION
`open` 方法实际支持打开 `TopologyData` 和 JSON 字符串两种格式类型的数据