### PR TITLE
fix: hoverLayer.ts 增加判断条件: 当节点有锚点时才显示自动锚点

### DIFF
--- a/packages/core/src/hoverLayer.ts
+++ b/packages/core/src/hoverLayer.ts
@@ -87,7 +87,8 @@ export class HoverLayer extends Layer {
           ctx.stroke();
         }
 
-        if (this.options.autoAnchor) {
+        //增加判断条件: 当节点有锚点时才显示自动锚点
+        if (this.options.autoAnchor && this.node.anchors.length) {
           ctx.beginPath();
           ctx.arc(
             (pen as Node).rect.center.x,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/le5le-com/topology/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
当我的节点没有设置锚点时，自动锚点仍可连接，且连接后画布崩溃；
这份提交增加了判断条件: 当节点有锚点时才显示自动锚点