### PR TITLE
底部对齐时 y 的计算问题

### DIFF
--- a/packages/core/src/middles/nodes/text.ts
+++ b/packages/core/src/middles/nodes/text.ts
@@ -204,7 +204,7 @@ export function text(ctx: CanvasRenderingContext2D, node: Pen) {
   const lines = getLines(ctx, node);
 
   const lineHeight = node.fontSize * node.lineHeight;
-  let maxLineLen = node.textMaxLine > 0 && node.textMaxLine < lines.length ? node.textMaxLine : lines.length;
+  const maxLineLen = node.textMaxLine > 0 && node.textMaxLine < lines.length ? node.textMaxLine : lines.length;
 
   // By default, the text is center aligned.
   let x = textRect.x + textRect.width / 2;
@@ -222,7 +222,7 @@ export function text(ctx: CanvasRenderingContext2D, node: Pen) {
       y = textRect.y + (lineHeight - node.fontSize) / 2;
       break;
     case 'bottom':
-      y = textRect.ey - lineHeight * lines.length + lineHeight;
+      y = textRect.ey - lineHeight * maxLineLen + lineHeight;
       break;
   }
   fillText(


### PR DESCRIPTION
有 textMaxLine 并且该值小于 lines 的长度时，说明有省略号，而且 y 轴的计算行数应该与 textMaxLine 相关