### PR TITLE
line calcTextRect from or to 有一个不存在时，textRect 为空

### DIFF
--- a/packages/core/src/models/line.ts
+++ b/packages/core/src/models/line.ts
@@ -277,7 +277,7 @@ export class Line extends Pen {
   }
 
   calcTextRect() {
-    if (!this.from || this.to) {
+    if (!this.from || !this.to) {
       this.textRect = undefined;
       return;
     }


### PR DESCRIPTION
上次写错了，导致官网目前的连线无法使用文字